### PR TITLE
Attempted to fix bug with tf.nn.conv1d

### DIFF
--- a/wavetf/_daubachies_conv.py
+++ b/wavetf/_daubachies_conv.py
@@ -213,7 +213,7 @@ class DaubWaveLayer2D(DirWaveLayer2D):
         else:
             s1 = self.daub_1(t1)
         ## s1: (b, c, ox, 2*ny)
-        s1 = tf.reshape(s1, [self.bs, self.cn*self.ox, -1, 1])
+        s1 = tf.reshape(s1, [self.bs*self.cn*self.ox, -1, 1])
         ## s1: (b, c*ox, 2*ny', 1)
         # build kernels and apply to rows
         k1l = tf.reshape(daubechies_ker[:,0], (4, 1, 1))
@@ -231,7 +231,7 @@ class DaubWaveLayer2D(DirWaveLayer2D):
             s2 = self.daub_1(t2)
         ## s2: (b, c, ny, 2_y, 2*nx)
         nx_dim = s2.shape[4]
-        s2 = tf.reshape(s2, [self.bs, self.cn*self.ny*2, nx_dim, 1])
+        s2 = tf.reshape(s2, [self.bs*self.cn*self.ny*2, nx_dim, 1])
         # out: (b, c*ny*2_y, 2*nx', 1)
         # build kernels and apply kernel to columns
         rl = tf.nn.conv1d(s2, k1l, stride=2, padding='VALID')
@@ -363,7 +363,7 @@ class InvDaubWaveLayer2D(InvWaveLayer2D):
         #######################################
         ## work on x
         #######################################
-        t1 = tf.reshape(t1, [self.bs, self.cn*self.oy, self.ox, 1])
+        t1 = tf.reshape(t1, [self.bs*self.cn*self.oy, self.ox, 1])
         # out: (b, c*oy, ox, 1)
         # apply kernel to x
         k1l = tf.reshape(daubechies_ker[:,0], (4, 1, 1))
@@ -398,7 +398,7 @@ class InvDaubWaveLayer2D(InvWaveLayer2D):
         s1 = tf.reshape(r, [self.bs, self.cn, self.oy, self.ox])
         # out: (b, c, oy, ox)
         s1 = tf.transpose(s1, perm=[0, 1, 3, 2]) # out: (b, c, ox, oy)
-        s1 = tf.reshape(s1, [self.bs, self.cn*self.ox, self.oy, 1])
+        s1 = tf.reshape(s1, [self.bs*self.cn*self.ox, self.oy, 1])
         # out: (b, c*ox, oy, 1)
         # apply kernel to y
         rl = tf.nn.conv1d(s1, k1l, stride=2, padding='VALID')

--- a/wavetf/_haar_conv.py
+++ b/wavetf/_haar_conv.py
@@ -159,7 +159,7 @@ class HaarWaveLayer2D(DirWaveLayer2D):
         else :
             s1 = self.haar_1(t1)
         ## s1: (b, c, ox, 2*ny)
-        s1 = tf.reshape(s1, [self.bs, self.cn*self.ox, 2*self.ny, 1])
+        s1 = tf.reshape(s1, [self.bs*self.cn*self.ox, 2*self.ny, 1])
         ## s1: (b, c*ox, 2*ny, 1)
         # build kernels and apply to rows
         k1l = tf.reshape(haar_ker[:,0], (2, 1, 1))
@@ -176,7 +176,7 @@ class HaarWaveLayer2D(DirWaveLayer2D):
         else :
             s2 = self.haar_1(t2)
         ## s2: (b, c, ny, 2_y, 2*nx)
-        s2 = tf.reshape(s2, [self.bs, self.cn*self.ny*2, 2*self.nx, 1])
+        s2 = tf.reshape(s2, [self.bs*self.cn*self.ny*2, 2*self.nx, 1])
         # out: (b, c*ny*2_y, 2*nx, 1)
         # build kernels and apply kernel to columns
         rl = tf.nn.conv1d(s2, k1l, stride=2, padding='VALID')
@@ -217,7 +217,7 @@ class InvHaarWaveLayer2D(InvWaveLayer2D):
         # out: (b, x, y, 2_y, 2_x, c)
         t1 = tf.transpose(t1, perm=[0, 5, 2, 3, 1, 4])
         # out: (b, c, y, 2_y, x, 2_x)
-        t1 = tf.reshape(t1, [self.bs, self.cn*self.oy, self.ox, 1])
+        t1 = tf.reshape(t1, [self.bs*self.cn*self.oy, self.ox, 1])
         # out: (b, c*oy, ox, 1)
         # apply kernel to x
         k1l = tf.reshape(haar_ker[:,0], (2, 1, 1))
@@ -228,7 +228,7 @@ class InvHaarWaveLayer2D(InvWaveLayer2D):
         s1 = tf.reshape(s1, [self.bs, self.cn, self.oy, self.ox])
         # out: (b, c, oy, ox)
         s1 = tf.transpose(s1, perm=[0, 1, 3, 2]) # out: (b, c, ox, oy)
-        s1 = tf.reshape(s1, [self.bs, self.cn*self.ox, self.oy, 1])
+        s1 = tf.reshape(s1, [self.bs*self.cn*self.ox, self.oy, 1])
         # out: (b, c*ox, oy, 1)
         # apply kernel to y
         rl = tf.nn.conv1d(s1, k1l, stride=2, padding='VALID')


### PR DESCRIPTION
For the 2-D wavelet transforms (both DB-2 and Haar), tf.nn.conv2d was complaining about the number of input dimensions.  Both wavelet transforms call tf.nn.conv1d, which adds a dimension to the input tensor and then calls tf.nn.conv2d.  For 2-D wavelet transform the input tensor is already 4-D (batch x row x column x channel), so when tf.nn.conv1d adds the extra dimension, the tensor becomes 5-D.  tf.nn.conv2d expects 4-D tensors, so it complains about receiving a 5-D tensor.

I *think* my reshaping fixed the problem.